### PR TITLE
feat: add meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,14 +19,14 @@
     <meta property="og:url" content="https://wordlists.assetnote.io/">
     <meta property="og:title" content="Assetnote Wordlists">
     <meta property="og:description" content="Wordlists that are up to date and effective against the most popular technologies on the internet.">
-    <meta property="og:image" content="https://securib.ee/images/assetnote.png">
+    <meta property="og:image" content="https://wordlists.assetnote.io/assets/assetnote.png">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://wordlists.assetnote.io/">
     <meta property="twitter:title" content="Assetnote Wordlists">
     <meta property="twitter:description" content="Wordlists that are up to date and effective against the most popular technologies on the internet.">
-    <meta property="twitter:image" content="https://securib.ee/images/assetnote.png">
+    <meta property="twitter:image" content="https://wordlists.assetnote.io/assets/assetnote.png">
 
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico"> 
     <link rel="stylesheet" href="assets/css/normalize.css?v=1">

--- a/index.html
+++ b/index.html
@@ -10,6 +10,24 @@
       
     </title>
     <meta name="viewport" content="width=device-width">
+    <!-- Primary Meta Tags -->
+    <meta name="title" content="Assetnote Wordlists">
+    <meta name="description" content="Wordlists that are up to date and effective against the most popular technologies on the internet.">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://wordlists.assetnote.io/">
+    <meta property="og:title" content="Assetnote Wordlists">
+    <meta property="og:description" content="Wordlists that are up to date and effective against the most popular technologies on the internet.">
+    <meta property="og:image" content="https://securib.ee/images/assetnote.png">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://wordlists.assetnote.io/">
+    <meta property="twitter:title" content="Assetnote Wordlists">
+    <meta property="twitter:description" content="Wordlists that are up to date and effective against the most popular technologies on the internet.">
+    <meta property="twitter:image" content="https://securib.ee/images/assetnote.png">
+
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico"> 
     <link rel="stylesheet" href="assets/css/normalize.css?v=1">
     <link rel="stylesheet" href="assets/css/main.css?v=1">


### PR DESCRIPTION
Hey, I hope all is well!

When sharing the awesome resource on Discord just now, I noticed that there were no meta tags present.

They are responsible for displaying the handy image and description when sharing a link.

So I thought, why not add it. I also create an image with the correct dimensions. All you have to do is download it and upload it to your own server.

Preview:
![assetnote metatags](https://user-images.githubusercontent.com/51520913/113086689-24a50c00-91b0-11eb-9d63-61050c24568d.png)
